### PR TITLE
[asciidoc] support author and email attributes

### DIFF
--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -222,7 +222,10 @@ public class Parser {
         }
 
         final var attributes = readAttributes(enclosingElement, reader, context == null ? null : context.resolver());
-        return buildHeader(title, author, revision, merge(attributes, preTitleOptions));
+        final var mergedAttributes = merge(attributes, preTitleOptions);
+        final var authorsFromAttributes = extractAuthorsFromAttributes(mergedAttributes);
+        final var allAuthors = Stream.concat(author.stream(), authorsFromAttributes.stream()).toList();
+        return buildHeader(title, allAuthors.isEmpty() ? NO_AUTHORS : allAuthors, revision, mergedAttributes);
     }
 
     private String readHeaderTitleLine(final Reader reader, final Map<String, String> preTitleOptions) {
@@ -317,7 +320,7 @@ public class Parser {
                 options = merge(options, Map.of("title", stripped.substring(1).strip()));
             } else if (Objects.equals("====", stripped)) {
                 Optional<Admonition.Level> level;
-                final var potentialLevel = options== null ? "" : options.getOrDefault("", "");
+                final var potentialLevel = options == null ? "" : options.getOrDefault("", "");
                 if (!potentialLevel.isBlank() &&
                         (potentialLevel.length() == 3 || potentialLevel.length() == 4 || potentialLevel.length() == 7 || potentialLevel.length() == 9) &&
                         (level = Stream.of(Admonition.Level.values())
@@ -2312,16 +2315,32 @@ public class Parser {
     }
 
     private Author parseSingleAuthor(final String authorLine) {
-        final int mailStart = authorLine.lastIndexOf('<');
-        if (mailStart > 0) {
-            final int mailEnd = authorLine.indexOf('>', mailStart);
-            if (mailEnd > 0) {
-                return new Author(authorLine.substring(0, mailStart).strip(), authorLine.substring(mailStart + 1, mailEnd).strip());
+        final int angleBracketStart = authorLine.lastIndexOf('<');
+        if (angleBracketStart > 0) {
+            final int angleBracketEnd = authorLine.indexOf('>', angleBracketStart);
+            if (angleBracketEnd > 0) {
+                return new Author(authorLine.substring(0, angleBracketStart).strip(), authorLine.substring(angleBracketStart + 1, angleBracketEnd).strip());
             }
         }
         return new Author(authorLine.strip(), "");
     }
 
+    private List<Author> extractAuthorsFromAttributes(final Map<String, String> attributes) {
+        final var author = attributes.get("author");
+        if (author == null || author.isBlank()) {
+            return List.of();
+        }
+        final int angleBracketStart = author.indexOf('<');
+        var parsedAuthor = author;
+        if (angleBracketStart > 0) {
+            parsedAuthor = author.substring(0, angleBracketStart).strip();
+        }
+        final int semicolonStart = parsedAuthor.indexOf(';');
+        if (semicolonStart > 0) {
+            parsedAuthor = parsedAuthor.substring(0, semicolonStart).strip();
+        }
+        return List.of(new Author(parsedAuthor, attributes.getOrDefault("email", "")));
+    }
     // revision number, revision date: revision revmark
     private Revision parseRevisionLine(final String revisionLine) {
         final int firstSep = revisionLine.indexOf(",");

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -277,6 +277,50 @@ class ParserTest {
     }
 
     @Test
+    void parseAuthorAttribute() {
+        final var header = new Parser().parseHeader(new Reader(List.of(
+                "= Title",
+                ":author: Dave Grohl",
+                ":email: grohl@foofighter.com")));
+        assertEquals("Title", header.title());
+        assertEquals(List.of(new Author("Dave Grohl", "grohl@foofighter.com")), header.author());
+        assertEquals(Map.of("author", "Dave Grohl", "email", "grohl@foofighter.com"), header.attributes());
+    }
+
+    @Test
+    void parseAuthorAttributeWithoutEmail() {
+        final var header = new Parser().parseHeader(new Reader(List.of(
+                "= Title",
+                ":author: Dave Grohl")));
+        assertEquals("Title", header.title());
+        assertEquals(List.of(new Author("Dave Grohl", "")), header.author());
+        assertEquals(Map.of("author", "Dave Grohl"), header.attributes());
+    }
+
+    @Test
+    void parseMultipleAuthorsWithAttributes() {
+        final var header = new Parser().parseHeader(new Reader(List.of(
+                "= Title",
+                ":author: Dave Grohl, Taylor Hawkins",
+                ":email: grohl@foofighter.com")));
+        assertEquals("Title", header.title());
+        assertEquals(List.of(new Author("Dave Grohl, Taylor Hawkins", "grohl@foofighter.com")), header.author());
+        assertEquals(Map.of("author", "Dave Grohl, Taylor Hawkins", "email", "grohl@foofighter.com"), header.attributes());
+    }
+
+    @Test
+    void parseAuthorLineAndAttributesCombined() {
+        final var header = new Parser().parseHeader(new Reader(List.of(
+                "= Title",
+                "John Doe <john@example.com>",
+                ":author: Dave Grohl",
+                ":email: grohl@foofighter.com")));
+        assertEquals("Title", header.title());
+        assertEquals(List.of(new Author("John Doe", "john@example.com"), new Author("Dave Grohl", "grohl@foofighter.com")), header.author());
+        assertEquals(Map.of("author", "Dave Grohl", "email", "grohl@foofighter.com"), header.attributes());
+    }
+
+    @Test
     void manPageTitle() {
         final var header = new Parser().parseHeader(new Reader(List.of("= ls(1)")));
         assertEquals("ls(1)", header.title());


### PR DESCRIPTION
Implement support for setting author information via document attributes:
- :author: attribute sets the author name(s)
- :email: attribute sets the email address
- Multiple authors can be separated by commas in the :author: attribute
- Authors from both the author line and attributes are merged together

This complies with the AsciiDoc specification for author attribute entries: https://docs.asciidoctor.org/asciidoc/latest/document/author-attribute-entries/

Closes #94