### PR TITLE
[asciidoc] Fixes #50, render callouts as asciidoctor does when icons are enabled

### DIFF
--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/model/Code.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/model/Code.java
@@ -15,10 +15,29 @@
  */
 package io.yupiik.asciidoc.model;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-public record Code(String value, List<CallOut> callOuts, Map<String, String> options, boolean inline) implements Element {
+/**
+ * A code (listing) block or an inline code span.
+ *
+ * @param value        the code, callout markers removed.
+ * @param options      the block options.
+ * @param inline       true for an inline code span.
+ * @param lineCallOuts one entry per line of {@code value}, listing the callouts whose markers ended that line
+ *                     (empty lists for lines without a marker); empty when the block has no callout.
+ */
+public record Code(String value, Map<String, String> options, boolean inline,
+                   List<List<CallOut>> lineCallOuts) implements Element {
+    /**
+     * @return the callouts of the block in the order their markers appear in the code, each one once even when its
+     * marker sits on several lines. Computed from {@link #lineCallOuts()} on each call.
+     */
+    public List<CallOut> callOuts() {
+        return lineCallOuts.stream().flatMap(Collection::stream).distinct().toList();
+    }
+
     @Override
     public ElementType type() {
         return ElementType.CODE;

--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -754,7 +754,7 @@ public class Parser {
                                             .stream()
                                             .map(e -> e instanceof Text t ? t.value() : e.toString() /* FIXME */)
                                             .collect(joining());
-                                    return new Code(elements, List.of(), Map.of(), true);
+                                    return new Code(elements, Map.of(), true, List.of());
                                 };
                             }
                             if (i.contains("h")) { // header
@@ -905,7 +905,7 @@ public class Parser {
             return new Paragraph(p.children(), Map.copyOf(opts));
         }
         if (element instanceof Code c) {
-            return new Code(c.value(), c.callOuts(), Map.copyOf(opts), c.inline());
+            return new Code(c.value(), Map.copyOf(opts), c.inline(), c.lineCallOuts());
         }
         return element;
     }
@@ -1055,23 +1055,31 @@ public class Parser {
         final var substitutions = resolveSubs(codeOptions.get("subs"), VERBATIM_SUBS);
         if (!substitutions.contains("callouts")) {
             // the block dropped the callout substitution so `<1>` is code text and the `<1> ...` lines after it are content
-            return new Code(subs(code, currentAttributes, substitutions), List.of(), codeOptions, false);
+            return new Code(subs(code, currentAttributes, substitutions), codeOptions, false, List.of());
         }
 
         final var contentWithCallouts = parseWithCallouts(code);
-        if (contentWithCallouts.callOutReferences().isEmpty()) {
-            return new Code(subs(code, currentAttributes, substitutions), List.of(), codeOptions, false);
+        if (contentWithCallouts.lineReferences().isEmpty()) {
+            return new Code(subs(code, currentAttributes, substitutions), codeOptions, false, List.of());
         }
 
         final var callOuts = parseCallOuts(enclosingDocument, reader, resolver, currentAttributes);
         final var numbers = callOuts.stream().map(CallOut::number).toList();
-        if (!numbers.containsAll(contentWithCallouts.callOutReferences()) &&
+        final var references = new HashSet<Integer>();
+        contentWithCallouts.lineReferences().forEach(references::addAll);
+        if (!numbers.containsAll(references) &&
                 // asciidoctor renders such a document with a warning; opt in to that with `:callout-mismatch: ignore`
                 !"ignore".equals(currentAttributes.getOrDefault("callout-mismatch", globalAttributes.get("callout-mismatch")))) {
             throw new IllegalArgumentException("Invalid callout references (code markers don't match post-code callouts) in snippet:\n" + snippet);
         }
 
-        return new Code(subs(contentWithCallouts.content(), currentAttributes, substitutions), callOuts, codeOptions, false);
+        // the markers are gone from the code, the model says which callouts ended each line
+        final var byNumber = new HashMap<Integer, CallOut>();
+        callOuts.forEach(c -> byNumber.putIfAbsent(c.number(), c));
+        final var lineCallOuts = contentWithCallouts.lineReferences().stream()
+                .map(refs -> refs.stream().map(byNumber::get).filter(Objects::nonNull).toList())
+                .toList();
+        return new Code(subs(contentWithCallouts.content(), currentAttributes, substitutions), codeOptions, false, lineCallOuts);
     }
 
     private List<CallOut> parseCallOuts(final Path enclosingDocument, final Reader reader,
@@ -1100,40 +1108,37 @@ public class Parser {
         return callOuts;
     }
 
+    // removes the `<n>` markers from the code and says, line by line, which numbers ended it
     private ContentWithCalloutIndices parseWithCallouts(final String snippet) {
-        StringBuilder out = null;
-        Set<Integer> callOuts = null;
         final var lines = snippet.split("\n");
-        for (int i = 0; i < lines.length; i++) {
-            final var line = lines[i];
+        final var out = new StringBuilder();
+        final var lineReferences = new ArrayList<List<Integer>>(lines.length);
+        boolean found = false;
+        for (final var line : lines) {
             final var matcher = CALLOUT_REF.matcher(line);
-            if (matcher.find()) {
-                if (out == null) {
-                    out = new StringBuilder();
-                    callOuts = new HashSet<>(2);
-                    if (i > 0) {
-                        Stream.of(lines).limit(i).map(l -> l + '\n').forEach(out::append);
-                    }
-                }
-                // a single line can carry several markers - `a=b <1><2>` - and each one is its own callout
-                final var rewritten = new StringBuilder();
-                do {
-                    final int number;
-                    try {
-                        number = Integer.parseInt(matcher.group("number"));
-                    } catch (final NumberFormatException nfe) {
-                        throw new IllegalArgumentException("Can't parse a callout on line '" + line + "' in\n" + snippet);
-                    }
-                    callOuts.add(number);
-                    matcher.appendReplacement(rewritten, "(" + number + ')');
-                } while (matcher.find());
-                matcher.appendTail(rewritten);
-                out.append(rewritten).append('\n');
-            } else if (out != null) {
+            if (!matcher.find()) {
+                lineReferences.add(List.of());
                 out.append(line).append('\n');
+                continue;
             }
+            found = true;
+            final var numbers = new ArrayList<Integer>(2); // a line can carry several markers, `a=b <1><2>`
+            final var stripped = new StringBuilder();
+            do {
+                try {
+                    numbers.add(Integer.parseInt(matcher.group("number")));
+                } catch (final NumberFormatException nfe) {
+                    throw new IllegalArgumentException("Can't parse a callout on line '" + line + "' in\n" + snippet);
+                }
+                matcher.appendReplacement(stripped, "");
+            } while (matcher.find());
+            matcher.appendTail(stripped);
+            lineReferences.add(List.copyOf(numbers));
+            out.append(stripped.toString().stripTrailing()).append('\n');
         }
-        return out == null ? new ContentWithCalloutIndices(snippet.stripTrailing(), List.of()) : new ContentWithCalloutIndices(out.toString(), callOuts);
+        return found ?
+                new ContentWithCalloutIndices(out.toString(), lineReferences) :
+                new ContentWithCalloutIndices(snippet.stripTrailing(), List.of());
     }
 
     private List<Element> handleIncludes(final Path enclosingDocument,
@@ -1758,7 +1763,7 @@ public class Parser {
                                                         .collect(toMap(Map.Entry::getKey, Map.Entry::getValue))));
                             }
                         } else {
-                            elements.add(new Code(content, List.of(), Map.of(), true));
+                            elements.add(new Code(content, Map.of(), true, List.of()));
                         }
                         i = end;
                         start = end + 1;
@@ -2790,7 +2795,7 @@ public class Parser {
             return new Text(t.style(), t.value(), merge(t.options(), element.options()));
         }
         if (first instanceof Code c) {
-            return new Code(c.value(), c.callOuts(), merge(c.options(), element.options()), c.inline());
+            return new Code(c.value(), merge(c.options(), element.options()), c.inline(), c.lineCallOuts());
         }
         if (first instanceof Link l) {
             return new Link(l.url(), l.label(), merge(l.options(), element.options()));
@@ -3077,7 +3082,7 @@ public class Parser {
     public record ParserContext(ContentResolver resolver) {
     }
 
-    private record ContentWithCalloutIndices(String content, Collection<Integer> callOutReferences) {
+    private record ContentWithCalloutIndices(String content, List<List<Integer>> lineReferences) {
     }
 
     private enum AuthorSource {

--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRenderer.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRenderer.java
@@ -988,16 +988,25 @@ public class AsciidoctorLikeHtmlRenderer implements Visitor<String> {
                 builder.append(" data-linenums=\"true\"");
             }
             builder.append(">");
-            var html = escape(element.value());
-            if (linenums) {
-                final var lines = html.split("\n");
-                final var numbered = new StringBuilder();
-                for (int i = 0; i < lines.length; i++) {
-                    numbered.append("<span class=\"linenums\">").append(i + 1).append("</span>").append(lines[i]).append('\n');
+            // the parser removed the markers from the code and says which callouts ended each line
+            final var highlight = !"false".equalsIgnoreCase(element.options().get("hightlight-callouts"));
+            final var icons = icons();
+            final var lines = element.value().split("\n", linenums ? 0 : -1);
+            for (int i = 0; i < lines.length; i++) {
+                if (linenums) {
+                    builder.append("<span class=\"linenums\">").append(i + 1).append("</span>");
                 }
-                html = numbered.toString();
+                builder.append(escape(lines[i]));
+                if (i < element.lineCallOuts().size() && !element.lineCallOuts().get(i).isEmpty()) {
+                    builder.append(' '); // markers sat at the end of the line, `a=b <1><2>` in the source
+                    for (final var callOut : element.lineCallOuts().get(i)) {
+                        builder.append(highlight ? callOutMarker(icons, callOut.number(), false) : "(" + callOut.number() + ")");
+                    }
+                }
+                if (linenums || i < lines.length - 1) {
+                    builder.append('\n');
+                }
             }
-            builder.append("false".equalsIgnoreCase(element.options().get("hightlight-callouts")) ? html : highlightCallOuts(element.callOuts(), html));
             builder.append("</code></pre>\n </div>\n </div>\n");
         } else {
             final var nowrap = element.options().containsKey("nowrap-option") || state.nowrap;
@@ -1007,26 +1016,45 @@ public class AsciidoctorLikeHtmlRenderer implements Visitor<String> {
             builder.append("</pre>\n </div>\n </div>\n");
         }
 
-        if (!element.callOuts().isEmpty()) {
+        final var callOuts = element.callOuts(); // derived from the lines, so materialized once
+        if (!callOuts.isEmpty()) {
+            final var icons = icons();
             builder.append(" <div class=\"colist arabic\">\n");
-            builder.append("  <ol>\n");
-            element.callOuts().forEach(c -> {
-                final boolean nowrap = state.nowrap;
-                builder.append("   <li>\n");
-                state.inCallOut = true;
-                state.nowrap = true;
-                if (c.text() instanceof Paragraph p && p.options().isEmpty()) {
-                    p.children().forEach(this::visitElement);
-                } else {
-                    visitElement(c.text());
-                }
-                state.inCallOut = false;
-                state.nowrap = nowrap;
-                builder.append("   </li>\n");
-            });
-            builder.append("  </ol>\n");
+            if (icons == null) {
+                builder.append("  <ol>\n");
+                callOuts.forEach(c -> {
+                    builder.append("   <li>\n");
+                    visitCallOutText(c);
+                    builder.append("   </li>\n");
+                });
+                builder.append("  </ol>\n");
+            } else { // as of asciidoctor, with icons the list is a table using the same markers as the code
+                builder.append("  <table>\n");
+                callOuts.forEach(c -> {
+                    builder.append("   <tr>\n");
+                    builder.append("    <td>").append(callOutMarker(icons, c.number(), true)).append("</td>\n");
+                    builder.append("    <td>\n");
+                    visitCallOutText(c);
+                    builder.append("    </td>\n");
+                    builder.append("   </tr>\n");
+                });
+                builder.append("  </table>\n");
+            }
             builder.append(" </div>\n");
         }
+    }
+
+    protected void visitCallOutText(final CallOut callOut) {
+        final boolean nowrap = state.nowrap;
+        state.inCallOut = true;
+        state.nowrap = true;
+        if (callOut.text() instanceof Paragraph p && p.options().isEmpty()) {
+            p.children().forEach(this::visitElement);
+        } else {
+            visitElement(callOut.text());
+        }
+        state.inCallOut = false;
+        state.nowrap = nowrap;
     }
 
     @Override
@@ -1294,7 +1322,7 @@ public class AsciidoctorLikeHtmlRenderer implements Visitor<String> {
                 }
             }
             case "mermaid" -> visitMermaid(element);
-            default -> visitCode(new Code(element.value(), List.of(), element.options(), false));
+            default -> visitCode(new Code(element.value(), element.options(), false, List.of()));
         }
     }
 
@@ -1921,6 +1949,11 @@ public class AsciidoctorLikeHtmlRenderer implements Visitor<String> {
         Visitor.super.visitMacro(element);
     }
 
+    /**
+     * @deprecated the parser records where the callouts sit ({@link Code#lineCallOuts()}) so the renderer no longer
+     * looks for markers in the code text; kept for subclasses, not called anymore.
+     */
+    @Deprecated
     protected String highlightCallOuts(final List<CallOut> callOuts, final String value) {
         if (callOuts.isEmpty()) {
             return value;
@@ -1930,6 +1963,23 @@ public class AsciidoctorLikeHtmlRenderer implements Visitor<String> {
             out = out.replace(" (" + i + ")", " <b class=\"conum\">(" + i + ")</b>");
         }
         return out;
+    }
+
+    // as of asciidoctor: plain `(N)` without icons, a conum with font icons, an image otherwise;
+    // in the callout list the number has no parentheses
+    protected String callOutMarker(final String icons, final int number, final boolean inList) {
+        final var label = inList ? Integer.toString(number) : "(" + number + ")";
+        if (icons == null) {
+            return "<b class=\"conum\">" + label + "</b>";
+        }
+        if ("font".equals(icons)) {
+            return "<i class=\"conum\" data-value=\"" + number + "\"></i><b>" + label + "</b>";
+        }
+        return "<img src=\"" + icons + "/callouts/" + number + ".png\" alt=\"" + number + '"' + voidSlash() + ">";
+    }
+
+    protected String icons() {
+        return attr("icons", state.document == null ? Map.<String, String>of() : state.document.header().attributes());
     }
 
     protected String escape(final String name) {

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -123,19 +123,19 @@ class ParserTest {
                 new DescriptionList(Map.of(
                         new Paragraph(List.of(
                                 new Text(List.of(), "generate-frisby-skeleton.output (env: ", Map.of()),
-                                new Code("GENERATE_FRISBY_SKELETON_OUTPUT", List.of(), Map.of(), true),
+                                new Code("GENERATE_FRISBY_SKELETON_OUTPUT", Map.of(), true, List.of()),
                                 new Text(List.of(), ")", Map.of())), Map.of()),
                         new Paragraph(List.of(
                                 new Text(List.of(), "Where to generate the skeleton. Default: ", Map.of()),
-                                new Code("hcms-frisby", List.of(), Map.of(), true),
+                                new Code("hcms-frisby", Map.of(), true, List.of()),
                                 new Text(List.of(), ".", Map.of())), Map.of()),
                         new Paragraph(List.of(
                                 new Text(List.of(), "hcms.database-init.enabled (env: ", Map.of()),
-                                new Code("HCMS_DATABASE_INIT_ENABLED", List.of(), Map.of(), true),
+                                new Code("HCMS_DATABASE_INIT_ENABLED", Map.of(), true, List.of()),
                                 new Text(List.of(), ")", Map.of())), Map.of()),
                         new Paragraph(List.of(
                                 new Text(List.of(), "Should database be initialized at startup. Default: ", Map.of()),
-                                new Code("true", List.of(), Map.of(), true),
+                                new Code("true", Map.of(), true, List.of()),
                                 new Text(List.of(), ".", Map.of())), Map.of())), Map.of())
         ), body.children());
     }
@@ -149,11 +149,11 @@ class ParserTest {
         assertEquals(List.of(
                 new UnOrderedList(List.of(
                         new Paragraph(List.of(
-                                new Code("alveolus.name", List.of(), Map.of(), true),
+                                new Code("alveolus.name", Map.of(), true, List.of()),
                                 new Text(List.of(), ": name of the alveolus the descriptor comes from,", Map.of())),
                                 Map.of()),
                         new Paragraph(List.of(
-                                new Code("descriptor.name", List.of(), Map.of(), true),
+                                new Code("descriptor.name", Map.of(), true, List.of()),
                                 new Text(List.of(), ": name of the descriptor,", Map.of())),
                                 Map.of())), Map.of())
         ), body.children());
@@ -1075,7 +1075,7 @@ class ParserTest {
                 ----
                 """.split("\n"))), null);
         assertEquals(
-                List.of(new Code("public record Foo() {\n}\n", List.of(), Map.of("language", "java", "role", "hljs"), false)),
+                List.of(new Code("public record Foo() {\n}\n", Map.of("language", "java", "role", "hljs"), false, List.of())),
                 body.children());
     }
 
@@ -1091,7 +1091,7 @@ class ParserTest {
                     ----
                 """.split("\n"))), null);
         assertEquals(
-                List.of(new Code("    <dependency>\n        <groupId>io.quarkiverse.qute.web</groupId>\n        <artifactId>quarkus-qute-web</artifactId>\n    </dependency>\n", List.of(), Map.of("language", "xml"), false)),
+                List.of(new Code("    <dependency>\n        <groupId>io.quarkiverse.qute.web</groupId>\n        <artifactId>quarkus-qute-web</artifactId>\n    </dependency>\n", Map.of("language", "xml"), false, List.of())),
                 body.children());
     }
 
@@ -1117,7 +1117,7 @@ class ParserTest {
                 ----
                 """.split("\n"))), null);
         assertEquals(
-                List.of(new Code("<script defer src=\"/js/test.js?v=1\"></script>\n", List.of(), Map.of("subs", "attributes"), false)),
+                List.of(new Code("<script defer src=\"/js/test.js?v=1\"></script>\n", Map.of("subs", "attributes"), false, List.of())),
                 body.children());
     }
 
@@ -1133,7 +1133,7 @@ class ParserTest {
                 ----
                 """, new Parser.ParserContext(ContentResolver.of(Path.of("target/missing"))));
         assertEquals(
-                List.of(new Code("foo(\"bar\");\n", List.of(), Map.of("language", "java", "subs", "attributes"), false)),
+                List.of(new Code("foo(\"bar\");\n", Map.of("language", "java", "subs", "attributes"), false, List.of())),
                 doc.body().children());
     }
 
@@ -1191,13 +1191,13 @@ class ParserTest {
                                 new Paragraph(
                                         List.of(
                                                 new Text(List.of(), "foo", Map.of()),
-                                                new Code("public record Foo() {\n\n}\n", List.of(), Map.of("language", "java", "role", "hljs"), false)
+                                                new Code("public record Foo() {\n\n}\n", Map.of("language", "java", "role", "hljs"), false, List.of())
                                         ),
                                         Map.of()),
                                 new Paragraph(
                                         List.of(
                                                 new Text(List.of(), "bar", Map.of()),
-                                                new Code("public record Bar() {\n\n}\n", List.of(), Map.of(), false)
+                                                new Code("public record Bar() {\n\n}\n", Map.of(), false, List.of())
                                         ),
                                         Map.of()),
                                 new Text(List.of(), "end", Map.of())),
@@ -1217,7 +1217,7 @@ class ParserTest {
                 ----
                 """.split("\n"))), ContentResolver.of(work));
         assertEquals(
-                List.of(new Code(code, List.of(), Map.of("language", "properties", "role", "hljs"), false)),
+                List.of(new Code(code, Map.of("language", "properties", "role", "hljs"), false, List.of())),
                 body.children());
     }
 
@@ -1233,7 +1233,7 @@ class ParserTest {
                 ----
                 """.split("\n"))), ContentResolver.of(work));
         assertEquals(
-                List.of(new Code("before\ninclude::content.properties[]\nafter\n", List.of(), Map.of("language", "asciidoc"), false)),
+                List.of(new Code("before\ninclude::content.properties[]\nafter\n", Map.of("language", "asciidoc"), false, List.of())),
                 body.children());
     }
 
@@ -1261,7 +1261,7 @@ class ParserTest {
                                 new Text(List.of(), "dummy", Map.of()),
                                 new Paragraph(List.of(
                                         new Text(List.of(), "something", Map.of()),
-                                        new Code("test\n\n", List.of(), Map.of(), false)
+                                        new Code("test\n\n", Map.of(), false, List.of())
                                 ), Map.of())
                         ), Map.of()),
                         new DescriptionList(Map.of(
@@ -1296,14 +1296,13 @@ class ParserTest {
                 """.split("\n"))), null);
         assertEquals(
                 List.of(
-                        new Code("a=b (1)\nc=d (2)\n", List.of(
-                                new CallOut(1, new Paragraph(List.of(
+                        new Code("a=b\nc=d\n", Map.of("language", "properties"), false, List.of(
+                                List.of(new CallOut(1, new Paragraph(List.of(
                                         new Text(List.of(), "one, like", Map.of()),
-                                        new Code("{\"a\": \"b\"}\n\n{\"c\": \"d\"}\n", List.of(), Map.of("language", "json"), false)), Map.of())),
-                                new CallOut(2, new Paragraph(List.of(
+                                        new Code("{\"a\": \"b\"}\n\n{\"c\": \"d\"}\n", Map.of("language", "json"), false, List.of())), Map.of()))),
+                                List.of(new CallOut(2, new Paragraph(List.of(
                                         new Text(List.of(), "two, and", Map.of()),
-                                        new Text(List.of(), "more text attached", Map.of())), Map.of()))),
-                                Map.of("language", "properties"), false),
+                                        new Text(List.of(), "more text attached", Map.of())), Map.of()))))),
                         new Text(List.of(), "after", Map.of())),
                 body.children());
     }
@@ -1342,7 +1341,7 @@ class ParserTest {
                 """.split("\n"))), null);
         assertEquals(
                 List.of(
-                        new Code("a=b (1)\nc=d (2)\n", List.of(), Map.of("language", "properties"), false),
+                        new Code("a=b\nc=d\n", Map.of("language", "properties"), false, List.of(List.of(), List.of())),
                         new OrderedList(List.of(
                                 new Text(List.of(), "one", Map.of()),
                                 new Text(List.of(), "two", Map.of())), Map.of("style", "arabic")),
@@ -1365,18 +1364,16 @@ class ParserTest {
                 <1> Defines a record,
                 <.> Defines an attribute of the record.
                 """.split("\n"))), null);
-        assertEquals(
+        final var record = new CallOut(1, new Text(List.of(), "Defines a record,", Map.of()));
+        final var attribute = new CallOut(2, new Text(List.of(), "Defines an attribute of the record.", Map.of()));
+        assertEquals( // the markers are gone from the code, lineCallOuts says where they were
                 List.of(new Code("""
                         import anything;
-                        public record Foo( (1)
-                          String name (2)
+                        public record Foo(
+                          String name
                         ) {
                         }
-                        """,
-                        List.of(
-                                new CallOut(1, new Text(List.of(), "Defines a record,", Map.of())),
-                                new CallOut(2, new Text(List.of(), "Defines an attribute of the record.", Map.of()))),
-                        Map.of("language", "java", "role", "hljs"), false)),
+                        """, Map.of("language", "java", "role", "hljs"), false, List.of(List.of(), List.of(record), List.of(attribute), List.of(), List.of()))),
                 body.children());
     }
 
@@ -1392,7 +1389,7 @@ class ParserTest {
                 """.split("\n"))), null);
         assertEquals(
                 List.of(
-                        new Code("foo(); // <1>\n", List.of(), Map.of("language", "java", "subs", "-callouts"), false),
+                        new Code("foo(); // <1>\n", Map.of("language", "java", "subs", "-callouts"), false, List.of()),
                         new Text(List.of(), "<1> not a callout, the block dropped that substitution.", Map.of())),
                 body.children());
     }
@@ -1409,7 +1406,7 @@ class ParserTest {
                 """.split("\n"))), null);
         assertEquals(
                 List.of(
-                        new Code("foo(); // <1>\n", List.of(), Map.of("language", "java", "subs", "attributes"), false),
+                        new Code("foo(); // <1>\n", Map.of("language", "java", "subs", "attributes"), false, List.of()),
                         new Text(List.of(), "<1> not a callout, this list replaces the default substitutions.", Map.of())),
                 body.children());
     }
@@ -1426,9 +1423,9 @@ class ParserTest {
                 """.split("\n"))), null);
         assertEquals(
                 List.of(new Code(
-                        "foo(\"bar\"); // (1)\n",
-                        List.of(new CallOut(1, new Text(List.of(), "a callout, the defaults are only extended.", Map.of()))),
-                        Map.of("language", "java", "subs", "+attributes"), false)),
+                        "foo(\"bar\"); //\n",
+                        Map.of("language", "java", "subs", "+attributes"), false,
+                        List.of(List.of(new CallOut(1, new Text(List.of(), "a callout, the defaults are only extended.", Map.of())))))),
                 body.children());
     }
 
@@ -1444,7 +1441,7 @@ class ParserTest {
                 """.split("\n"))), null);
         assertEquals(
                 List.of(
-                        new Code("foo(\"bar\"); // <1>\n", List.of(), Map.of("language", "java", "subs", "normal"), false),
+                        new Code("foo(\"bar\"); // <1>\n", Map.of("language", "java", "subs", "normal"), false, List.of()),
                         new Text(List.of(), "<1> not a callout, the normal group has no callout substitution.", Map.of())),
                 body.children());
     }
@@ -1463,12 +1460,12 @@ class ParserTest {
                 """.split("\n"))), null);
         assertEquals(
                 List.of(new Code(
-                        "quarkus.arc.exclude-types=org.acme.Foo,org.acme.*,Bar (1)(2)(3)\n",
-                        List.of(
+                        "quarkus.arc.exclude-types=org.acme.Foo,org.acme.*,Bar\n",
+                        Map.of("language", "properties"), false,
+                        List.of(List.of(
                                 new CallOut(1, new Text(List.of(), "a class,", Map.of())),
                                 new CallOut(2, new Text(List.of(), "a package,", Map.of())),
-                                new CallOut(3, new Text(List.of(), "a pattern.", Map.of()))),
-                        Map.of("language", "properties"), false)),
+                                new CallOut(3, new Text(List.of(), "a pattern.", Map.of())))))),
                 body.children());
     }
 
@@ -1560,7 +1557,7 @@ class ParserTest {
                                 new Paragraph(
                                         List.of(
                                                 new Text(List.of(), "item 1", Map.of()),
-                                                new Code("record Foo() {}\n", List.of(), Map.of("language", "java"), false)),
+                                                new Code("record Foo() {}\n", Map.of("language", "java"), false, List.of())),
                                         Map.of()),
                                 new Text(List.of(), "item 2", Map.of())), Map.of())),
                 body.children());
@@ -2047,7 +2044,7 @@ class ParserTest {
                         List.of(
                                 new Paragraph(List.of(
                                         new Text(List.of(), "Cell in column 1, row 1", Map.of()),
-                                        new Code("public class Foo {\n}\n", List.of(), Map.of("language", "java"), false)
+                                        new Code("public class Foo {\n}\n", Map.of("language", "java"), false, List.of())
                                 ), Map.of()),
                                 new Text(List.of(), "Cell in column 2, row 1", Map.of())),
                         List.of(

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRendererTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRendererTest.java
@@ -17,7 +17,10 @@ package io.yupiik.asciidoc.renderer.html;
 
 import io.yupiik.asciidoc.parser.Parser;
 import io.yupiik.asciidoc.model.Body;
+import io.yupiik.asciidoc.model.CallOut;
+import io.yupiik.asciidoc.model.Code;
 import io.yupiik.asciidoc.model.Document;
+import io.yupiik.asciidoc.model.Text;
 import io.yupiik.asciidoc.parser.internal.Reader;
 import io.yupiik.asciidoc.parser.resolver.ContentResolver;
 import org.junit.jupiter.api.Test;
@@ -569,6 +572,60 @@ class AsciidoctorLikeHtmlRendererTest {
                  </p>
                  </div>
                 """);
+    }
+
+    @Test
+    void calloutWithIcons() { // as of asciidoctor, icons make the markers conums and the callout list a table
+        assertRenderingContent("""
+                :icons: font
+                                
+                [source,properties]
+                ----
+                a=b <1>
+                c=d <2>
+                ----
+                <1> one,
+                <2> two.
+                """, """
+                 <div class="listingblock">
+                 <div class="content">
+                 <pre class="highlightjs highlight"><code class="language-properties hljs" data-lang="properties">a=b <i class="conum" data-value="1"></i><b>(1)</b>
+                c=d <i class="conum" data-value="2"></i><b>(2)</b>
+                </code></pre>
+                 </div>
+                 </div>
+                 <div class="colist arabic">
+                  <table>
+                   <tr>
+                    <td><i class="conum" data-value="1"></i><b>1</b></td>
+                    <td>
+                 <span>
+                one,
+                 </span>
+                    </td>
+                   </tr>
+                   <tr>
+                    <td><i class="conum" data-value="2"></i><b>2</b></td>
+                    <td>
+                 <span>
+                two.
+                 </span>
+                    </td>
+                   </tr>
+                  </table>
+                 </div>
+                """);
+    }
+
+    @Test
+    void severalCalloutMarkersOnTheSameLine() { // `a=b <1><2>` in the source
+        final var one = new CallOut(1, new Text(List.of(), "one,", Map.of()));
+        final var two = new CallOut(2, new Text(List.of(), "two.", Map.of()));
+        final var renderer = new AsciidoctorLikeHtmlRenderer();
+        renderer.visitCode(new Code("a=b\n", Map.of("language", "properties"), false, List.of(List.of(one, two))));
+        assertTrue(
+                renderer.result().contains("a=b <b class=\"conum\">(1)</b><b class=\"conum\">(2)</b>"),
+                renderer::result);
     }
 
     @Test


### PR DESCRIPTION
Reworked after the two reviews: the model carries the callout positions, the renderer no longer parses the code text, and the record has no redundant component.

- `Code` is now `(value, options, inline, lineCallOuts)`: `lineCallOuts` holds one list per line of `value` with the callouts whose markers ended that line (empty lists for lines without one; empty when the block has no callout), and the parser removes the `<N>` markers from the code instead of rewriting them to `(N)`, so `value` is the plain code. `callOuts()` stays as a derived accessor (each callout once, in order of appearance) for the callout list and for compatibility; the library reads `lineCallOuts` itself and materializes the flat list once. The old constructor is gone rather than kept as one that cannot carry positions.
- The renderer writes the markers from `lineCallOuts` while emitting the lines, so a decorating visitor does no extra work. With `:icons:` set the marker is `<i class="conum" data-value="N"></i><b>(N)</b>` and the callout list is a table, which is what the asciidoctor stylesheet styles (`.conum[data-value]`, the difference in the screenshots of #50); without the attribute the output is byte-identical to before. `hightlight-callouts=false` prints `(N)` as text, as before.
- One protected method, `callOutMarker(icons, number, inList)`, covers the code and the list. `highlightCallOuts` is kept and deprecated.
- Several markers on one line come for free from the model (`a=b <1><2>`), so this overlaps with #112's hunk in `parseWithCallouts`; whichever lands second needs a trivial rebase.

Tests: `codeWithCallout` asserts the stripped code and the positions; `calloutWithIcons`, `severalCalloutMarkersOnTheSameLine`; the existing `callout` and `callouts` renderer tests pass unchanged. Today's quarkus.io guide sources: 317 of 327 parse with this branch alone, the rest being the shapes #117 covers.

Fixes #50.
