### PR TITLE
[asciidoc] Fixes #106, accept several callout markers on a single code line

### DIFF
--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -1114,13 +1114,20 @@ public class Parser {
                         Stream.of(lines).limit(i).map(l -> l + '\n').forEach(out::append);
                     }
                 }
-                try {
-                    final var number = Integer.parseInt(matcher.group("number"));
+                // a single line can carry several markers - `a=b <1><2>` - and each one is its own callout
+                final var rewritten = new StringBuilder();
+                do {
+                    final int number;
+                    try {
+                        number = Integer.parseInt(matcher.group("number"));
+                    } catch (final NumberFormatException nfe) {
+                        throw new IllegalArgumentException("Can't parse a callout on line '" + line + "' in\n" + snippet);
+                    }
                     callOuts.add(number);
-                    out.append(matcher.replaceAll("(" + number + ')')).append('\n');
-                } catch (final NumberFormatException nfe) {
-                    throw new IllegalArgumentException("Can't parse a callout on line '" + line + "' in\n" + snippet);
-                }
+                    matcher.appendReplacement(rewritten, "(" + number + ')');
+                } while (matcher.find());
+                matcher.appendTail(rewritten);
+                out.append(rewritten).append('\n');
             } else if (out != null) {
                 out.append(line).append('\n');
             }

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -1327,6 +1327,29 @@ class ParserTest {
     }
 
     @Test
+    void codeWithSeveralCalloutsOnTheSameLine() {
+        final var body = new Parser().parseBody(new Reader(List.of("""
+                [source,properties]
+                ----
+                quarkus.arc.exclude-types=org.acme.Foo,org.acme.*,Bar <1><2><3>
+                ----
+                                
+                <1> a class,
+                <2> a package,
+                <3> a pattern.
+                """.split("\n"))), null);
+        assertEquals(
+                List.of(new Code(
+                        "quarkus.arc.exclude-types=org.acme.Foo,org.acme.*,Bar (1)(2)(3)\n",
+                        List.of(
+                                new CallOut(1, new Text(List.of(), "a class,", Map.of())),
+                                new CallOut(2, new Text(List.of(), "a package,", Map.of())),
+                                new CallOut(3, new Text(List.of(), "a pattern.", Map.of()))),
+                        Map.of("language", "properties"), false)),
+                body.children());
+    }
+
+    @Test
     void unorderedList() {
         final var body = new Parser().parseBody(new Reader(List.of("""
                 * item 1


### PR DESCRIPTION
`a=b <1><2>` is valid asciidoctor: each marker is a distinct callout. The parser only read the first marker of a line, replaced every marker of that line with the first number, and then rejected the block because the number of references no longer matched the number of callouts.

The other half of #106, keeping the document when the callout list does not match the markers, is #117, which also parses the list shapes behind most of those mismatches (a list separated from its block by a paragraph, items with blocks attached with `+`).

Test: `codeWithSeveralCalloutsOnTheSameLine`.

Fixes #106.
