### PR TITLE
[asciidoc] Fixes #107, treat ''' as a thematic break

### DIFF
--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -2702,7 +2702,8 @@ public class Parser {
             return false;
         }
         final var first = stripped.charAt(0);
-        if (first != '-' && first != '*' && first != '_') {
+        // ''' is the asciidoc thematic break, --- *** and ___ are the markdown ones
+        if (first != '-' && first != '*' && first != '_' && first != '\'') {
             return false;
         }
         for (int i = 1; i < stripped.length(); i++) {

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -2195,6 +2195,12 @@ class ParserTest {
     }
 
     @Test
+    void horizontalRuleApostrophes() { // the asciidoc thematic break
+        final var body = new Parser().parseBody(new Reader(List.of("'''")), null);
+        assertEquals(List.of(new HorizontalRule(Map.of())), body.children());
+    }
+
+    @Test
     void horizontalRuleLonger() {
         final var body = new Parser().parseBody(new Reader(List.of("-----")), null);
         assertEquals(List.of(new HorizontalRule(Map.of())), body.children());


### PR DESCRIPTION
`'''` is the asciidoc thematic break; `---`, `***` and `___` are the markdown alternatives (asciidoctor's `ExtLayoutBreakRx`). Only the markdown ones produced a `HorizontalRule`, so a `'''` line came out as a paragraph of three apostrophes.

Test: `horizontalRuleApostrophes`.

Fixes #107.
