### PR TITLE
[asciidoc] Fixes #108, keep trailing punctuation out of bare urls

### DIFF
--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -2843,11 +2843,11 @@ public class Parser {
             if (next == nextEmail) {
                 end = emailMatcher.end();
             } else {
-                end = Stream.of(" ", "\t")
+                end = endOfBareLink(content, next, Stream.of(" ", "\t")
                         .mapToInt(s -> content.indexOf(s, next))
                         .filter(i -> i > next)
                         .min()
-                        .orElseGet(content::length);
+                        .orElseGet(content::length));
             }
 
             if (start != next) {
@@ -2862,6 +2862,21 @@ public class Parser {
             }
             start = end;
         }
+    }
+
+    // as of asciidoctor, a bare url stops before the punctuation which follows it: `see https://yupiik.io, then`
+    private int endOfBareLink(final String content, final int from, final int end) {
+        int last = end;
+        while (last > from && ",.?!)".indexOf(content.charAt(last - 1)) >= 0) {
+            last--;
+        }
+        if (last > from && (content.charAt(last - 1) == ';' || content.charAt(last - 1) == ':')) {
+            last--;
+            while (last > from && content.charAt(last - 1) == ')') { // `(https://yupiik.io);`
+                last--;
+            }
+        }
+        return LINK_PREFIXES.contains(content.substring(from, last)) ? end : last; // keep bare schemes as they are
     }
 
     private int findNextLink(final String line, final int from) {

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -858,6 +858,24 @@ class ParserTest {
     }
 
     @Test
+    void linkTrailingPunctuation() { // as of asciidoctor the punctuation which follows a bare url is not part of it
+        assertEquals(
+                List.of(new Paragraph(List.of(
+                        new Text(List.of(), "See ", Map.of()),
+                        new Link("https://yupiik.io", new Text(List.of(), "https://yupiik.io", Map.of("nowrap", "true")), Map.of()),
+                        new Text(List.of(), "; then ", Map.of()),
+                        new Link("https://www.yupiik.io", new Text(List.of(), "https://www.yupiik.io", Map.of("nowrap", "true")), Map.of()),
+                        new Text(List.of(), ", ok.", Map.of())), Map.of())),
+                new Parser().parseBody(new Reader(List.of("See https://yupiik.io; then https://www.yupiik.io, ok.")), null).children());
+        assertEquals(
+                List.of(new Paragraph(List.of(
+                        new Text(List.of(), "(see ", Map.of()),
+                        new Link("https://yupiik.io", new Text(List.of(), "https://yupiik.io", Map.of("nowrap", "true")), Map.of()),
+                        new Text(List.of(), ") and more", Map.of())), Map.of())),
+                new Parser().parseBody(new Reader(List.of("(see https://yupiik.io) and more")), null).children());
+    }
+
+    @Test
     void linkInCode() {
         final var body = new Parser().parseBody(new Reader(List.of("`https://yupiik.io[Yupiik OSS]`")), null);
         assertEquals(


### PR DESCRIPTION
A bare url used to run to the next blank, so `see https://yupiik.io, and` gave a link to `https://yupiik.io,`. As of asciidoctor (`InlineLinkRx` and its post-processing in `sub_macros`) a bare url stops before a trailing `, . ? ! )`, and a trailing `;` or `:` is moved out of it too, `);` included. A bare scheme such as `https://` is left as it is.

Same limit as asciidoctor: a bare url ending with `)` loses it, so a url like `.../Foo_(bar)` needs the macro form.

Test: `linkTrailingPunctuation`.

Fixes #108.
