### PR TITLE
[asciidoc] Fixes #110, no NullPointerException on bold text starting with a list marker

### DIFF
--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -1142,7 +1142,8 @@ public class Parser {
         int start = 0;
         boolean inMacro = false;
         for (int i = 0; i < line.length(); i++) {
-            if (supportComplexStructures) {
+            // without a reader the line is inline content - the text of `**1. Bold**` for ex - so it holds no block
+            if (supportComplexStructures && reader != null) {
                 if (i == line.length() - 2 && line.endsWith(" +")) {
                     elements.add(new LineBreak());
                     break;

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -2102,6 +2102,19 @@ class ParserTest {
     }
 
     @Test
+    void markdownBoldStartingWithAListMarker() { // `1. ` is a list marker for a line, not inside a bold span
+        final var body = new Parser().parseBody(new Reader(List.of("**1. Bold** text.")), null);
+        assertEquals(List.of(new Paragraph(List.of(
+                new Text(List.of(BOLD), "1. Bold", Map.of()),
+                new Text(List.of(), " text.", Map.of())), Map.of())), body.children());
+
+        final var title = new Parser().parseBody(new Reader(List.of("===== **1. Memory Usage Metrics**")), null);
+        assertEquals(
+                List.of(new Section(5, new Text(List.of(BOLD), "1. Memory Usage Metrics", Map.of()), List.of(), Map.of())),
+                title.children());
+    }
+
+    @Test
     void markdownStrikethrough() {
         final var body = new Parser().parseBody(new Reader(List.of("This is ~~deleted~~ text.")), null);
         assertEquals(List.of(new Paragraph(List.of(


### PR DESCRIPTION
Inline content is parsed without a reader, so the block structures tried on it (lists, description lists, admonitions) rewound a null reader: `**1. Bold**` threw a NullPointerException, and so did a section title written that way (`===== **1. Memory Usage Metrics**` in the quarkus.io micrometer guide). The content of a styled span is now parsed as inline text only, which is what asciidoctor does.

Test: `markdownBoldStartingWithAListMarker`.

Fixes #110.
