### PR TITLE
[asciidoc] Parse callout lists after a paragraph and with attached blocks, never drop the document

### DIFF
--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -498,11 +498,8 @@ public class Parser {
                     elements.add(parseSection(enclosingDocument, reader, options, resolver, attributes));
                 }
                 options = null;
-            } else if (Objects.equals("----", stripped)) {
-                elements.add(parseCodeBlock(enclosingDocument, reader, options, resolver, attributes, "----"));
-                options = null;
-            } else if (Objects.equals("```", stripped)) {
-                elements.add(parseCodeBlock(enclosingDocument, reader, options, resolver, attributes, "```"));
+            } else if (Objects.equals("----", stripped) || Objects.equals("```", stripped)) {
+                elements.add(parseCodeBlock(enclosingDocument, reader, options, resolver, attributes, stripped));
                 options = null;
             } else if (Objects.equals("--", stripped)) {
                 elements.add(parseOpenBlock(enclosingDocument, reader, options, resolver, attributes, "--"));
@@ -1066,7 +1063,21 @@ public class Parser {
             return new Code(subs(code, currentAttributes, substitutions), List.of(), codeOptions, false);
         }
 
-        final var callOuts = new ArrayList<CallOut>(contentWithCallouts.callOutReferences().size());
+        final var callOuts = parseCallOuts(enclosingDocument, reader, resolver, currentAttributes);
+        final var numbers = callOuts.stream().map(CallOut::number).toList();
+        if (!numbers.containsAll(contentWithCallouts.callOutReferences()) &&
+                // asciidoctor renders such a document with a warning; opt in to that with `:callout-mismatch: ignore`
+                !"ignore".equals(currentAttributes.getOrDefault("callout-mismatch", globalAttributes.get("callout-mismatch")))) {
+            throw new IllegalArgumentException("Invalid callout references (code markers don't match post-code callouts) in snippet:\n" + snippet);
+        }
+
+        return new Code(subs(contentWithCallouts.content(), currentAttributes, substitutions), callOuts, codeOptions, false);
+    }
+
+    private List<CallOut> parseCallOuts(final Path enclosingDocument, final Reader reader,
+                                        final ContentResolver resolver, final Map<String, String> currentAttributes) {
+        final var callOuts = new ArrayList<CallOut>();
+        String next;
         Matcher matcher;
         while ((next = reader.skipCommentsAndEmptyLines()) != null && (matcher = CALLOUT.matcher(next)).matches()) {
             int number;
@@ -1077,26 +1088,16 @@ public class Parser {
                 throw new IllegalArgumentException("Invalid callout: '" + next + "'");
             }
 
-            var text = matcher.group("description");
-            while ((next = reader.nextLine()) != null && !next.startsWith("<") && !next.isBlank()) {
-                text += '\n' + next;
-            }
-            if (next != null && !next.isBlank() && next.startsWith("<")) {
-                reader.rewind();
-            }
+            final var text = new StringBuilder(matcher.group("description"));
+            readContinuation(reader, l -> CALLOUT.matcher(l).matches(), text);
 
-            final var elements = doParse(enclosingDocument, new Reader(List.of(text.split("\n"))), l -> true, resolver, currentAttributes, true, false);
+            final var elements = doParse(enclosingDocument, new Reader(List.of(text.toString().split("\n"))), l -> true, resolver, currentAttributes, true, false);
             callOuts.add(new CallOut(number, elements.size() == 1 ? elements.get(0) : new Paragraph(elements, Map.of())));
         }
-        if (next != null && !next.isBlank()) {
+        if (next != null) {
             reader.rewind();
         }
-
-        if (callOuts.size() != contentWithCallouts.callOutReferences().size()) { // todo: enhance
-            throw new IllegalArgumentException("Invalid callout references (code markers don't match post-code callouts) in snippet:\n" + snippet);
-        }
-
-        return new Code(subs(contentWithCallouts.content(), currentAttributes, substitutions), callOuts, codeOptions, false);
+        return callOuts;
     }
 
     private ContentWithCalloutIndices parseWithCallouts(final String snippet) {
@@ -2227,7 +2228,8 @@ public class Parser {
                 final var markerLen = "dots".equals(captureName) ?
                         matcher.group("prefix").length() + matcher.group("dots").length() :
                         prefix.length();
-                readContinuation(reader, regex, buffer, nextStripped, markerLen);
+                buffer.append(nextStripped.substring(markerLen).stripLeading());
+                readContinuation(reader, l -> regex.matcher(l.strip()).matches(), buffer);
 
                 final var rawContent = buffer.toString();
                 final var checkMatcher = CHECKBOX.matcher(rawContent);
@@ -2271,10 +2273,9 @@ public class Parser {
         return factory.apply(children, listOptions);
     }
 
-    private void readContinuation(final Reader reader, final Pattern regex, final StringBuilder buffer,
-                                  final String nextStripped, final int markerLen) {
-        buffer.append(nextStripped.substring(markerLen).stripLeading());
-
+    // reads the rest of a list item - text wrapping on the next lines, blocks attached with `+` - until a blank
+    // line or the next item (stopsAt); shared by the ordered, unordered and callout lists
+    private void readContinuation(final Reader reader, final Predicate<String> stopsAt, final StringBuilder buffer) {
         String next;
         String needed = null;
         while ((next = reader.nextLine()) != null) {
@@ -2287,7 +2288,7 @@ public class Parser {
             } else if ("+".equals(next.strip())) { // continuation
                 buffer.append('\n');
                 continue;
-            } else if (needed == null && regex.matcher(next.strip()).matches()) {
+            } else if (needed == null && stopsAt.test(next)) {
                 break;
             }
             buffer.append('\n').append(next);

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -64,6 +64,8 @@ import static io.yupiik.asciidoc.model.Text.Style.MARK;
 import static io.yupiik.asciidoc.model.Text.Style.STRIKETHROUGH;
 import static java.util.Map.entry;
 import static java.util.stream.Collectors.toMap;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
@@ -1224,6 +1226,84 @@ class ParserTest {
                                 new Text(List.of(), "end", Map.of())
                         ), Map.of())
                 ), Map.of())),
+                body.children());
+    }
+
+    @Test
+    void codeCalloutsWithAttachedBlocks() { // `+` attaches the next block to the item, read as for any list item
+        final var body = new Parser().parseBody(new Reader(List.of("""
+                [source,properties]
+                ----
+                a=b <1>
+                c=d <2>
+                ----
+                <1> one, like
+                +
+                [source,json]
+                ----
+                {"a": "b"}
+
+                {"c": "d"}
+                ----
+                <2> two, and
+                +
+                more text attached
+
+                after
+                """.split("\n"))), null);
+        assertEquals(
+                List.of(
+                        new Code("a=b (1)\nc=d (2)\n", List.of(
+                                new CallOut(1, new Paragraph(List.of(
+                                        new Text(List.of(), "one, like", Map.of()),
+                                        new Code("{\"a\": \"b\"}\n\n{\"c\": \"d\"}\n", List.of(), Map.of("language", "json"), false)), Map.of())),
+                                new CallOut(2, new Paragraph(List.of(
+                                        new Text(List.of(), "two, and", Map.of()),
+                                        new Text(List.of(), "more text attached", Map.of())), Map.of()))),
+                                Map.of("language", "properties"), false),
+                        new Text(List.of(), "after", Map.of())),
+                body.children());
+    }
+
+    @Test
+    void codeCalloutsMismatchFails() {
+        final var reader = new Reader(List.of("""
+                [source,properties]
+                ----
+                a=b <1>
+                c=d <2>
+                ----
+
+                1. one
+                2. two
+                """.split("\n")));
+        final var error = assertThrows(IllegalArgumentException.class, () -> new Parser().parseBody(reader, null));
+        assertTrue(error.getMessage().startsWith("Invalid callout references"), error::getMessage);
+    }
+
+    @Test
+    void codeCalloutsMismatchIgnoredOnDemand() { // :callout-mismatch: ignore keeps the document, as asciidoctor does
+        final var body = new Parser().parseBody(new Reader(List.of("""
+                :callout-mismatch: ignore
+
+                [source,properties]
+                ----
+                a=b <1>
+                c=d <2>
+                ----
+
+                1. one
+                2. two
+
+                after
+                """.split("\n"))), null);
+        assertEquals(
+                List.of(
+                        new Code("a=b (1)\nc=d (2)\n", List.of(), Map.of("language", "properties"), false),
+                        new OrderedList(List.of(
+                                new Text(List.of(), "one", Map.of()),
+                                new Text(List.of(), "two", Map.of())), Map.of("style", "arabic")),
+                        new Text(List.of(), "after", Map.of())),
                 body.children());
     }
 


### PR DESCRIPTION
Reworked after the review: the detached-list support is gone, failure stays the default, tolerance is opt-in, and there is no logger.

Two things asciidoctor accepts in a callout list that the parser did not:

- An item can carry blocks attached with `+`, as for any list item; the continuation reader is the one the ordered and unordered lists use, `readContinuation`, which now takes its stop condition as a predicate (the next list marker there, the next `<n>` line here). The AsciiDoc docs on compound list items name callout lists explicitly ("callout and description lists also support compound list items"), and the Quarkus guides use it (`elasticsearch.adoc`, `hibernate-orm.adoc`). Item text can also wrap on a line starting with `<`, such as an xref.
- A list that does not match the markers still renders in asciidoctor, with a warning. The parser keeps throwing by default, as before; `:callout-mismatch: ignore`, as a document attribute or a parser attribute, opts into keeping the code with the callouts it read. The name follows asciidoctor's `attribute-missing`; happy to rename it.

A callout list separated from its block by a paragraph is not supported, on purpose: the docs place the list below the block with nothing between, and Quarkus moved its own lists for that reason (quarkusio/quarkus#56222, quarkusio/quarkus#56449).

On today's quarkus.io guide sources (327 files) this branch parses 319 by default (the rest are genuine mismatches in the sources, plus #110 which #116 fixed) and 326 with the attribute set.

Tests: `codeCalloutsWithAttachedBlocks`, `codeCalloutsMismatchFails`, `codeCalloutsMismatchIgnoredOnDemand`.

Relates to #106.

