### PR TITLE
[asciidoc] Fixes #118, don't read callout markers when the block drops that substitution

### DIFF
--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -58,6 +58,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -128,6 +129,18 @@ public class Parser {
     private static final Pattern REVISION_INFO = Pattern.compile("^(?:[^\\d{]*(.*?),)? *(?!:)(.*?)(?: *(?!^),?: *(.*))?$");
     private static final Pattern XML_TAG = Pattern.compile("<[^>]+>");
     private static final List<String> PREPROCESSOR_MACROS = List.of("ifdef", "ifndef", "ifeval", "endif", "include");
+    // substitutions as asciidoctor names them, a block selects them in its subs option (see resolveSubs()).
+    // the parser acts on two of them only: callouts (parseCodeBlock()) and attributes (subs()).
+    // specialcharacters, quotes, replacements, macros and post_replacements are resolved so that the +/- modifiers
+    // and the groups compute the right set, but change nothing here: a verbatim block is stored as written and
+    // the renderer always escapes it.
+    private static final Set<String> NO_SUBS = Set.of(); // passthrough block default
+    private static final Set<String> VERBATIM_SUBS = Set.of("specialcharacters", "callouts"); // listing, literal and source block default
+    private static final Map<String, List<String>> SUB_GROUPS = Map.of(
+            "none", List.of(),
+            "normal", List.of("specialcharacters", "quotes", "attributes", "replacements", "macros", "post_replacements"),
+            "verbatim", List.of("specialcharacters", "callouts"),
+            "specialchars", List.of("specialcharacters"));
 
     private final Map<String, String> globalAttributes;
 
@@ -584,8 +597,10 @@ public class Parser {
 
         final var text = content.toString();
         final var actualOpts = options == null ? Map.<String, String>of() : options;
+        // a literal block ("....") is verbatim, a passthrough block ("++++") has no substitution by default
+        final var substitutions = resolveSubs(actualOpts.get("subs"), "....".equals(marker) ? VERBATIM_SUBS : NO_SUBS);
         if (!text.contains("include::")) {
-            return new PassthroughBlock(subs(text, actualOpts), actualOpts);
+            return new PassthroughBlock(subs(text, actualOpts, substitutions), actualOpts);
         }
 
         final var filtered = Stream.of(text.split("\n"))
@@ -601,19 +616,58 @@ public class Parser {
                     }
                 })
                 .collect(joining("\n"));
-        return new PassthroughBlock(subs(filtered, actualOpts), actualOpts);
+        return new PassthroughBlock(subs(filtered, actualOpts, substitutions), actualOpts);
     }
 
-    private String subs(final String value, final Map<String, String> opts) {
-        final var subs = opts.get("subs");
-        var out = value;
-        if (subs == null) {
-            return out;
+    /**
+     * Resolves the substitutions of a block from its {@code subs} option the way asciidoctor does:
+     * an entry carrying a modifier - {@code +name}, {@code name+} or {@code -name} - changes the block defaults,
+     * entries without one form a list which replaces them.
+     * Groups are expanded, ie {@code verbatim} is {@code specialcharacters,callouts},
+     * {@code normal} does not contain {@code callouts} and {@code none} is empty.
+     * The single letter hints ({@code a}, {@code q}, ...) belong to the inline pass macro, not to blocks, so they are not resolved.
+     *
+     * @param subs     the raw {@code subs} option value, can be {@code null} when the block has none.
+     * @param defaults the substitutions the block gets without a {@code subs} option.
+     * @return the substitution names applying to the block.
+     */
+    private Set<String> resolveSubs(final String subs, final Set<String> defaults) {
+        if (subs == null || subs.isBlank()) {
+            return defaults;
         }
-        if (subs.contains("attributes") && !subs.contains("-attributes")) {
-            out = earlyAttributeReplacement(out, opts);
+        Set<String> resolved = null;
+        for (final var entry : subs.split(",")) {
+            var name = entry.strip();
+            if (name.isEmpty()) {
+                continue;
+            }
+            boolean modifier = true;
+            boolean remove = false;
+            if (name.startsWith("+")) {
+                name = name.substring(1);
+            } else if (name.startsWith("-")) {
+                remove = true;
+                name = name.substring(1);
+            } else if (name.endsWith("+")) {
+                name = name.substring(0, name.length() - 1);
+            } else {
+                modifier = false;
+            }
+            if (resolved == null) { // the first entry says if the list modifies the defaults or replaces them
+                resolved = modifier ? new LinkedHashSet<>(defaults) : new LinkedHashSet<>();
+            }
+            final var expanded = SUB_GROUPS.getOrDefault(name, List.of(name));
+            if (remove) {
+                resolved.removeAll(expanded);
+            } else {
+                resolved.addAll(expanded);
+            }
         }
-        return out;
+        return resolved == null ? defaults : resolved;
+    }
+
+    private String subs(final String value, final Map<String, String> opts, final Set<String> substitutions) {
+        return substitutions.contains("attributes") ? earlyAttributeReplacement(value, opts) : value;
     }
 
     private OpenBlock parseOpenBlock(final Path enclosingDocument, final Reader reader, final Map<String, String> options,
@@ -1000,9 +1054,15 @@ public class Parser {
         final var code = snippet.stream().filter(Text.class::isInstance).map(Text.class::cast).map(Text::value).collect(joining());
         final var codeOptions = options == null ? Map.<String, String>of() : options;
 
+        final var substitutions = resolveSubs(codeOptions.get("subs"), VERBATIM_SUBS);
+        if (!substitutions.contains("callouts")) {
+            // the block dropped the callout substitution so `<1>` is code text and the `<1> ...` lines after it are content
+            return new Code(subs(code, codeOptions, substitutions), List.of(), codeOptions, false);
+        }
+
         final var contentWithCallouts = parseWithCallouts(code);
         if (contentWithCallouts.callOutReferences().isEmpty()) {
-            return new Code(subs(code, codeOptions), List.of(), codeOptions, false);
+            return new Code(subs(code, codeOptions, substitutions), List.of(), codeOptions, false);
         }
 
         final var callOuts = new ArrayList<CallOut>(contentWithCallouts.callOutReferences().size());
@@ -1035,7 +1095,7 @@ public class Parser {
             throw new IllegalArgumentException("Invalid callout references (code markers don't match post-code callouts) in snippet:\n" + snippet);
         }
 
-        return new Code(subs(contentWithCallouts.content(), codeOptions), callOuts, codeOptions, false);
+        return new Code(subs(contentWithCallouts.content(), codeOptions, substitutions), callOuts, codeOptions, false);
     }
 
     private ContentWithCalloutIndices parseWithCallouts(final String snippet) {

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -1216,6 +1216,75 @@ class ParserTest {
     }
 
     @Test
+    void codeWithCalloutsDisabledBySubs() {
+        final var body = new Parser().parseBody(new Reader(List.of("""
+                [source,java,subs="-callouts"]
+                ----
+                foo(); // <1>
+                ----
+
+                <1> not a callout, the block dropped that substitution.
+                """.split("\n"))), null);
+        assertEquals(
+                List.of(
+                        new Code("foo(); // <1>\n", List.of(), Map.of("language", "java", "subs", "-callouts"), false),
+                        new Text(List.of(), "<1> not a callout, the block dropped that substitution.", Map.of())),
+                body.children());
+    }
+
+    @Test
+    void codeWithCalloutsDisabledByASubsListWithoutThem() {
+        final var body = new Parser().parseBody(new Reader(List.of("""
+                [source,java,subs="attributes"]
+                ----
+                foo(); // <1>
+                ----
+
+                <1> not a callout, this list replaces the default substitutions.
+                """.split("\n"))), null);
+        assertEquals(
+                List.of(
+                        new Code("foo(); // <1>\n", List.of(), Map.of("language", "java", "subs", "attributes"), false),
+                        new Text(List.of(), "<1> not a callout, this list replaces the default substitutions.", Map.of())),
+                body.children());
+    }
+
+    @Test
+    void codeWithCalloutsKeptByAnIncrementalSubs() { // +attributes adds to the verbatim defaults, so the callout stays and the attribute is replaced
+        final var body = new Parser(Map.of("foo", "bar")).parseBody(new Reader(List.of("""
+                [source,java,subs="+attributes"]
+                ----
+                foo("{foo}"); // <1>
+                ----
+
+                <1> a callout, the defaults are only extended.
+                """.split("\n"))), null);
+        assertEquals(
+                List.of(new Code(
+                        "foo(\"bar\"); // (1)\n",
+                        List.of(new CallOut(1, new Text(List.of(), "a callout, the defaults are only extended.", Map.of()))),
+                        Map.of("language", "java", "subs", "+attributes"), false)),
+                body.children());
+    }
+
+    @Test
+    void codeWithNormalSubs() { // normal contains attributes but not callouts
+        final var body = new Parser(Map.of("foo", "bar")).parseBody(new Reader(List.of("""
+                [source,java,subs="normal"]
+                ----
+                foo("{foo}"); // <1>
+                ----
+
+                <1> not a callout, the normal group has no callout substitution.
+                """.split("\n"))), null);
+        assertEquals(
+                List.of(
+                        new Code("foo(\"bar\"); // <1>\n", List.of(), Map.of("language", "java", "subs", "normal"), false),
+                        new Text(List.of(), "<1> not a callout, the normal group has no callout substitution.", Map.of())),
+                body.children());
+    }
+
+    @Test
     void unorderedList() {
         final var body = new Parser().parseBody(new Reader(List.of("""
                 * item 1

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRendererTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRendererTest.java
@@ -548,6 +548,30 @@ class AsciidoctorLikeHtmlRendererTest {
     }
 
     @Test
+    void calloutSubstitutionDisabled() {
+        assertRenderingContent("""
+                [source,java,subs="-callouts"]
+                ----
+                foo(); // <1>
+                ----
+
+                <1> not a callout, the block dropped that substitution.
+                """, """
+                 <div class="listingblock">
+                 <div class="content">
+                 <pre class="highlightjs highlight"><code class="language-java hljs" data-lang="java">foo(); // &lt;1&gt;
+                </code></pre>
+                 </div>
+                 </div>
+                 <div class="paragraph">
+                 <p>
+                &lt;1&gt; not a callout, the block dropped that substitution.
+                 </p>
+                 </div>
+                """);
+    }
+
+    @Test
     void ol() {
         assertRenderingContent("""
                 . first


### PR DESCRIPTION
A verbatim block substitutes `specialcharacters,callouts` by default, so `subs="-callouts"`, and any replacement list without callouts such as `subs="attributes"` or `subs="none"`, take the callout substitution away. `<1>` is then code text, and a `<1> ...` line after the block is an ordinary paragraph. The parser read the markers anyway: it rewrote them to `(1)` when a matching list happened to follow, and threw `Invalid callout references` otherwise.

`subs` is now resolved the way asciidoctor does it: an entry carrying a modifier (`+name`, `name+` or `-name`) changes the block defaults, a list without one replaces them, and the `none`, `normal`, `verbatim` and `specialchars` groups are expanded. The attribute substitution reads the same resolved set, with the block's own defaults (verbatim for listing, literal and source blocks, nothing for a passthrough block), so `subs="normal"` substitutes attributes too. The parser acts on `callouts` and `attributes` only; the other names are resolved so that the modifiers and the groups compute the right set, and change nothing, which a comment next to the constants states.

Tests: `codeWithCalloutsDisabledBySubs`, `codeWithCalloutsDisabledByASubsListWithoutThem`, `codeWithCalloutsKeptByAnIncrementalSubs` and `codeWithNormalSubs` in `ParserTest`, plus `calloutSubstitutionDisabled` in `AsciidoctorLikeHtmlRendererTest`, which asserts the markers render escaped, with no conum and no callout list.

Corpus: on today's quarkusio/quarkus guides (327 files), with #111, #112 and #117 applied, this takes doc-create-tutorial.adoc from rejected to parsed. That guide shows AsciiDoc callout syntax as example text, which is why it disables the substitution six times.

Fixes #118.
