### PR TITLE
[asciidoc] Fixes #122, no endless evaluation of a self-referencing attribute value

### DIFF
--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -217,7 +217,7 @@ public class Parser {
         var revision = NO_REVISION;
         if (!title.isEmpty()) {
             // attribute entries can precede the author line, in particular when it references one of them
-            attributes.putAll(readAttributes(enclosingElement, reader, resolver));
+            attributes.putAll(readAttributes(enclosingElement, reader, resolver, attributes));
 
             final var authorLine = reader.nextLine();
             if (authorLine == null || authorLine.isBlank()) {
@@ -254,7 +254,7 @@ public class Parser {
         }
 
         final var beforeAuthorLine = Map.copyOf(attributes);
-        attributes.putAll(readAttributes(enclosingElement, reader, resolver));
+        attributes.putAll(readAttributes(enclosingElement, reader, resolver, attributes));
         return buildHeader(title, authors, revision, merge(attributes, preTitleOptions), beforeAuthorLine);
     }
 
@@ -566,8 +566,8 @@ public class Parser {
                     } catch (final RuntimeException nfe) { // NumberFormatException mainly
                         attributes.put(rawName, value);
                     }
-                } else {
-                    attributes.put(rawName, value);
+                } else { // as asciidoctor, the references are substituted before the assignment, unknown ones are kept as is
+                    attributes.put(rawName, earlyAttributeReplacement(value, attributes));
                 }
             } else {
                 reader.rewind();
@@ -1314,7 +1314,7 @@ public class Parser {
                             flushText(elements, line.substring(start, i));
                         }
                         final var attributeName = line.substring(i + 1, end);
-                        elements.add(new Attribute(attributeName, value -> doParse(enclosingDocument, new Reader(List.of(value)), l -> true, resolver, new HashMap<>(currentAttributes), true, false)));
+                        elements.add(lazyAttribute(enclosingDocument, attributeName, resolver, currentAttributes, Set.of(attributeName)));
                         i = end;
                         start = end + 1;
                     }
@@ -1827,6 +1827,40 @@ public class Parser {
         return strip.startsWith("\"") && strip.endsWith("\"") && strip.length() > 1 ? strip.substring(1, strip.length() - 1) : strip;
     }
 
+    // a reference is evaluated when it is rendered, its value can come from the renderer configuration, by parsing the
+    // value as a line of the document. so a value referencing a name which is being evaluated (":a: ${a}") must keep
+    // the reference literal, as asciidoctor keeps an unresolvable reference, otherwise the evaluation never ends.
+    // the guard follows the chain of evaluations since a cycle can go through several names.
+    private Attribute lazyAttribute(final Path enclosingDocument, final String name, final ContentResolver resolver,
+                                    final Map<String, String> currentAttributes, final Set<String> evaluating) {
+        return new Attribute(name, value -> {
+            final var parsed = keepLiteralReferences(
+                    doParse(enclosingDocument, new Reader(List.of(value)), l -> true, resolver, new HashMap<>(currentAttributes), true, false),
+                    evaluating);
+            // a value is inline content but the parsing wraps it in a paragraph when it has several elements
+            return parsed.size() == 1 && parsed.get(0) instanceof Paragraph p && p.options().isEmpty() ? p.children() : parsed;
+        });
+    }
+
+    private List<Element> keepLiteralReferences(final List<Element> elements, final Set<String> evaluating) {
+        return elements.stream()
+                .map(it -> {
+                    if (it instanceof Attribute a) {
+                        if (evaluating.contains(a.attribute())) {
+                            return new Text(List.of(), '{' + a.attribute() + '}', Map.of());
+                        }
+                        final var chain = new HashSet<>(evaluating);
+                        chain.add(a.attribute());
+                        return new Attribute(a.attribute(), value -> keepLiteralReferences(a.evaluator().apply(value), chain));
+                    }
+                    if (it instanceof Paragraph p) { // the shape a one-line value takes
+                        return new Paragraph(keepLiteralReferences(p.children(), evaluating), p.options());
+                    }
+                    return it;
+                })
+                .toList();
+    }
+
     private String earlyAttributeReplacement(final String value, final Map<String, String> attributes) {
         return earlyAttributeReplacement(value, attributes::get);
     }
@@ -1847,7 +1881,11 @@ public class Parser {
         for (final var key : keys) {
             final var placeholder = '{' + key + '}';
             final var replacement = attributes.apply(key);
-            out = out.replace(placeholder, replacement == null ? globalAttributes.getOrDefault(key, placeholder) : replacement);
+            final var resolved = replacement == null ? globalAttributes.getOrDefault(key, placeholder) : replacement;
+            if (resolved.contains(placeholder)) { // ":a: ${a}", inlining it would create a new reference to evaluate, the lazy evaluation handles it
+                continue;
+            }
+            out = out.replace(placeholder, resolved);
         }
         return out;
     }
@@ -2611,7 +2649,10 @@ public class Parser {
         return new Revision(number, date, remark);
     }
 
-    private Map<String, String> readAttributes(final Path enclosingElement, final Reader reader, final ContentResolver resolver) {
+    // knownAttributes are the ones read before this batch (a header has one before and one after the author line),
+    // a value can reference them as well as the ones of the batch
+    private Map<String, String> readAttributes(final Path enclosingElement, final Reader reader, final ContentResolver resolver,
+                                               final Map<String, String> knownAttributes) {
         Map<String, String> attributes = new LinkedHashMap<>();
         String line;
         while ((line = reader.nextLine()) != null) {
@@ -2638,8 +2679,11 @@ public class Parser {
                 final var rawName = matcher.group("name");
                 if (rawName.startsWith("!")) {
                     attributes.remove(rawName.substring(1));
-                } else {
-                    attributes.put(rawName, value);
+                } else { // as asciidoctor, the references are substituted before the assignment, unknown ones are kept as is
+                    attributes.put(rawName, earlyAttributeReplacement(value, name -> {
+                        final var local = attributes.get(name);
+                        return local != null ? local : knownAttributes.get(name);
+                    }));
                 }
             } else if (isBlockMacro(line)) {
                 // simplistic macro handling, mainly for conditional blocks since we still are in headers

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -2609,4 +2609,34 @@ class ParserTest {
                 List.of(new Text(List.of(), "snippet b", Map.of())),
                 body.children());
     }
+
+    @Test
+    void attributeValueSubstitutedWhenAssigned() { // #122, as asciidoctor the value is resolved before the assignment, not when referenced
+        final var doc = new Parser().parse(List.of(
+                ":a: 1", ":b: {a}", ":a: 2", "", "b is {b}, a is {a}."), new Parser.ParserContext(null));
+        assertEquals("1", doc.header().attributes().get("b"));
+        assertEquals(List.of(new Text(List.of(), "b is 1, a is 2.", Map.of())), doc.body().children());
+    }
+
+    @Test
+    void attributeValueSubstitutedWhenAssignedInTheBody() {
+        final var doc = new Parser().parse(List.of(
+                "= Title", "", ":a: 1", ":b: {a}", ":a: 2", "", "b is {b}, a is {a}."), new Parser.ParserContext(null));
+        assertEquals(List.of(new Text(List.of(), "b is 1, a is 2.", Map.of())), doc.body().children());
+    }
+
+    @Test
+    void attributeValueSubstitutedAcrossTheAuthorLine() {
+        final var header = new Parser().parseHeader(new Reader(List.of(
+                "= Title", ":a: 1", "Dave Grohl", ":b: {a}", "", "content")));
+        assertEquals("1", header.attributes().get("b"));
+    }
+
+    @Test
+    void attributeValueKeepsUnknownReferences() { // #122, asciidoctor keeps a reference it can not resolve as is
+        final var header = new Parser().parseHeader(new Reader(List.of(
+                ":a: ${a}", ":b: x{c}y", "", "content")));
+        assertEquals("${a}", header.attributes().get("a"));
+        assertEquals("x{c}y", header.attributes().get("b"));
+    }
 }

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRendererTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRendererTest.java
@@ -2656,6 +2656,50 @@ class AsciidoctorLikeHtmlRendererTest {
                         "</html>\n");
     }
 
+    @Test
+    void selfReferencingAttribute() { // #122, "a" is unknown when it is assigned so the reference stays in the value, which is then text
+        assertRenderingContainsLines("""
+                :a: ${a}
+                
+                See {a} here.
+                """, "<p>See ${a} here.</p>");
+    }
+
+    @Test
+    void selfReferencingAttributeWithSurroundingText() {
+        assertRenderingContainsLines("""
+                :a: x{a}y
+                
+                See {a} here.
+                """, "<p>See x{a}y here.</p>");
+    }
+
+    @Test
+    void attributeValueWithSeveralElements() { // the evaluated value is inline content, not a nested paragraph
+        final var doc = new Parser().parseBody("Hi {x}.", new Parser.ParserContext(ContentResolver.of(Path.of("target/missing"))));
+        final var renderer = new AsciidoctorLikeHtmlRenderer(new AsciidoctorLikeHtmlRenderer.Configuration()
+                .setAttributes(Map.of("noheader", "true", "x", "*bold* text")));
+        renderer.visitBody(doc);
+        assertEquals("""
+                 <div class="paragraph">
+                 <p>Hi <strong>bold</strong> text.</p>
+                 </div>
+                """, renderer.result());
+    }
+
+    @Test
+    void attributeCycleInTheRendererConfiguration() { // the names are unknown to the parser so the cycle only exists when rendering
+        final var doc = new Parser().parseBody("Cycle: {x}.", new Parser.ParserContext(ContentResolver.of(Path.of("target/missing"))));
+        final var renderer = new AsciidoctorLikeHtmlRenderer(new AsciidoctorLikeHtmlRenderer.Configuration()
+                .setAttributes(Map.of("noheader", "true", "x", "{y}", "y", "{x}")));
+        renderer.visitBody(doc);
+        assertEquals("""
+                 <div class="paragraph">
+                 <p>Cycle: {x}.</p>
+                 </div>
+                """, renderer.result());
+    }
+
     private void assertRenderingContainsLines(final String adoc, final String... lines) {
         final var doc = new Parser().parse(adoc, new Parser.ParserContext(ContentResolver.of(Path.of("target/missing"))));
         final var renderer = new AsciidoctorLikeHtmlRenderer();


### PR DESCRIPTION
An attribute reference is evaluated when it is rendered, by parsing its value as a line of the document, so `:a: ${a}` produced a new reference to `a` at each evaluation and the renderer overflowed the stack (the frames of #122).

Two changes, following the asciidoctor rules quoted in #122:

- The references of a value are substituted when the entry is processed, against the attributes known at that point, and a reference which can't be resolved is kept as is. So `:b: {a}` takes the value `a` has at that point (`b is 1, a is 2.` for the redefinition example of #122) and `:a: ${a}` stores the literal `${a}`. This applies to the header, to an attribute file included in the header, and to the body.
- A value which still references its own name is not inlined at parse time, the evaluation handles it: `keepLiteralReferences()` turns a reference to a name being evaluated into text, so `See {a} here.` renders `See ${a} here.` as asciidoctor does. The guard follows the chain of evaluations since a cycle can also go through names only the renderer configuration knows (`x` = `{y}` and `y` = `{x}` in `Configuration.setAttributes()`).

The lazy evaluation stays for the names the parser doesn't know, so an attribute only set on the renderer still resolves. While there: an evaluated value with several elements (`*bold* text`) was rendered as a nested paragraph, a value is inline content, so it is rendered inline now.

Tests: `attributeValueSubstitutedWhenAssigned`, `attributeValueSubstitutedWhenAssignedInTheBody`, `attributeValueSubstitutedAcrossTheAuthorLine` and `attributeValueKeepsUnknownReferences` (parser); `selfReferencingAttribute`, `selfReferencingAttributeWithSurroundingText`, `attributeCycleInTheRendererConfiguration` and `attributeValueWithSeveralElements` (renderer).

On the 327 quarkusio/quarkus guides of #122, against master at 0c0fe43: 83 of the 312 guides which parse overflowed, none does now, and the other 15 are the callout list shapes of #117. On the Maven-filtered copy of the same guides, the HTML of 9 guides changes, 71 lines, every one a reference inside an attribute value which was left as is before and is resolved now (`{quarkus-version}` in the javadoc urls of `rest.adoc`, the Hibernate versions in the dialect links of `hibernate-orm.adoc`), which is what asciidoctor prints too; nothing else changes.

Not changed here: a reference to a missing attribute still renders nothing, where asciidoctor keeps it in the output (`attribute-missing=skip`). It is a one-line change in `Visitor.visitAttribute()` but a visible one for existing documents, so I left it out; happy to send it if you want it.

Fixes #122.
