### PR TITLE
[asciidoc] Fixes #102, read the inline form of ifdef/ifndef

### DIFF
--- a/_documentation/src/main/minisite/content/asciidoc-java.adoc
+++ b/_documentation/src/main/minisite/content/asciidoc-java.adoc
@@ -46,7 +46,7 @@ The parser supports standard Asciidoc syntax including:
 * Open/closed blocks, quote blocks, listing blocks, example blocks
 * Macros (`image:`, `video:`, `audio:`, `icon:`, `btn:`, `kbd:`, `menu:`, `xref:`, footnote)
 * Include directives with `tag`/`tags`/`lines`/`leveloffset`/`indent` filtering
-* Conditionals (`ifdef::[]`, `ifndef::[]`, `ifeval::[]` with `else::[]`, `elsif::[]`)
+* Conditionals (`ifdef::[]`, `ifndef::[]`, `ifeval::[]` with `else::[]`, `elsif::[]`), the inline form `ifdef::name[content]` and multi-attribute conditions (`name1,name2` for an or, `name1+name2` for an and)
 * Attributes and substitutions (`:name: value`, `{name}`, `:!name:` to unset, `\{name}` escaping)
 * Callouts, footnotes, index terms, counters
 * Table features: colspan, rowspan, header option, autowidth, stripes, column alignment

--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/model/ConditionalBlock.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/model/ConditionalBlock.java
@@ -18,6 +18,8 @@ package io.yupiik.asciidoc.model;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static io.yupiik.asciidoc.model.Element.ElementType.CONDITIONAL_BLOCK;
 
@@ -25,6 +27,9 @@ public record ConditionalBlock(Predicate<Context> evaluator,
                                List<Element> children,
                                List<ConditionalBlock> elseBranches,
                                Map<String, String> options) implements Element {
+    private static final Pattern OR_SEPARATOR = Pattern.compile(",");
+    private static final Pattern AND_SEPARATOR = Pattern.compile("\\+");
+
     public ConditionalBlock(final Predicate<Context> evaluator,
                             final List<Element> children,
                             final Map<String, String> options) {
@@ -36,6 +41,24 @@ public record ConditionalBlock(Predicate<Context> evaluator,
         return CONDITIONAL_BLOCK;
     }
 
+    // as of asciidoctor a condition can list several attributes, "," being an "or" and "+" an "and",
+    // the two separators are not combinable so the first one found wins,
+    // an empty name ("a+" or "+" alone) is an undefined attribute
+    private static boolean isDefined(final String attribute, final Context context) {
+        if (attribute.indexOf(',') >= 0) {
+            return names(attribute, OR_SEPARATOR).anyMatch(it -> context.attribute(it) != null);
+        }
+        if (attribute.indexOf('+') >= 0) {
+            return names(attribute, AND_SEPARATOR).allMatch(it -> context.attribute(it) != null);
+        }
+        return context.attribute(attribute) != null;
+    }
+
+    private static Stream<String> names(final String attribute, final Pattern separator) {
+        return Stream.of(separator.split(attribute, -1)) // negative limit to keep the trailing empty names
+                .map(String::strip);
+    }
+
     @FunctionalInterface
     public interface Context {
         String attribute(String key);
@@ -44,14 +67,14 @@ public record ConditionalBlock(Predicate<Context> evaluator,
     public record Ifdef(String attribute) implements Predicate<Context> {
         @Override
         public boolean test(final Context context) {
-            return context.attribute(attribute) != null;
+            return isDefined(attribute, context);
         }
     }
 
     public record Ifndef(String attribute) implements Predicate<Context> {
         @Override
         public boolean test(final Context context) {
-            return context.attribute(attribute) == null;
+            return !isDefined(attribute, context);
         }
     }
 

--- a/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
+++ b/asciidoc-java/src/main/java/io/yupiik/asciidoc/parser/Parser.java
@@ -1634,13 +1634,17 @@ public class Parser {
                                 switch (macro.name()) {
                                     case "include" ->
                                             elements.addAll(doInclude(enclosingDocument, macro, resolver, currentAttributes, true));
-                                    case "ifdef" -> {
-                                        final var ifBlock = readIfBlock(reader);
-                                        elements.add(parseConditionalBlock("ifdef", macro.label(), ifBlock, enclosingDocument, resolver, currentAttributes, macro.options()));
-                                    }
-                                    case "ifndef" -> {
-                                        final var ifBlock = readIfBlock(reader);
-                                        elements.add(parseConditionalBlock("ifndef", macro.label(), ifBlock, enclosingDocument, resolver, currentAttributes, macro.options()));
+                                    case "ifdef", "ifndef" -> {
+                                        // ifdef::attr[content] is the inline form: the content sits in the brackets
+                                        // and there is no endif::[], so nothing more is read from the document
+                                        final var enclosed = line.substring(i + 1, end);
+                                        final var inline = !enclosed.isBlank();
+                                        final var ifBlock = inline ?
+                                                new IfBlock(List.of(enclosed), List.of(List.of(enclosed)), List.of()) :
+                                                readIfBlock(reader);
+                                        elements.add(parseConditionalBlock(
+                                                macro.name(), macro.label(), ifBlock, enclosingDocument, resolver, currentAttributes,
+                                                inline ? Map.of() : macro.options()));
                                     }
                                     case "ifeval" -> {
                                         final var condition = macro.label().isBlank() ? line.substring(i + 1, end).strip() : macro.label().strip();
@@ -2715,54 +2719,62 @@ public class Parser {
                     }));
                 }
             } else if (isBlockMacro(line)) {
-                // simplistic macro handling, mainly for conditional blocks since we still are in headers
+                // simplistic macro handling, mainly for conditional blocks since we still are in headers,
+                // HEADER_MACRO guarantees the "::" and the trailing "[...]" so no need to guard the indexes
                 final var stripped = line.strip();
-                final int options = stripped.indexOf("[]");
-                if (stripped.length() - "[]".length() == options) { // endsWith
-                    final int sep = stripped.indexOf("::");
-                    if (sep > 0) {
-                        final var macro = new Macro(
-                                stripped.substring(0, sep),
-                                stripped.substring(sep + "::".length(), options),
-                                Map.of(), false);
-                        if ("ifdef".equals(macro.name()) || "ifndef".equals(macro.name()) || "ifeval".equals(macro.name())) {
-                            final var ifBlock = readIfBlock(reader);
+                final int sep = stripped.indexOf("::");
+                final int options = stripped.indexOf('[', sep);
+                final var macro = new Macro(
+                        stripped.substring(0, sep),
+                        stripped.substring(sep + "::".length(), options),
+                        Map.of(), false);
+                // what sits in the brackets: empty for the block form (it is closed by a endif::[]),
+                // the conditioned content itself for the inline form of ifdef/ifndef which has no endif::[]
+                final var enclosed = stripped.substring(options + 1, stripped.length() - 1);
+                if ("ifdef".equals(macro.name()) || "ifndef".equals(macro.name()) || "ifeval".equals(macro.name())) {
+                    final var ctx = new ConditionalBlock.Context() {
+                        @Override
+                        public String attribute(final String key) {
+                            return attributes.getOrDefault(key, globalAttributes.get(key));
+                        }
+                    };
+                    final boolean branchMatched = switch (macro.name()) {
+                        case "ifdef" -> new ConditionalBlock.Ifdef(macro.label()).test(ctx);
+                        case "ifndef" -> new ConditionalBlock.Ifndef(macro.label()).test(ctx);
+                        case "ifeval" ->
+                                new ConditionalBlock.Ifeval(parseCondition(macro.label().strip(), attributes)).test(ctx);
+                        default -> false; // not possible
+                    };
 
-                            final var ctx = new ConditionalBlock.Context() {
-                                @Override
-                                public String attribute(final String key) {
-                                    return attributes.getOrDefault(key, globalAttributes.get(key));
-                                }
-                            };
-                            boolean branchMatched = switch (macro.name()) {
-                                case "ifdef" -> new ConditionalBlock.Ifdef(macro.label()).test(ctx);
-                                case "ifndef" -> new ConditionalBlock.Ifndef(macro.label()).test(ctx);
-                                case "ifeval" ->
-                                        new ConditionalBlock.Ifeval(parseCondition(macro.label().strip(), attributes)).test(ctx);
-                                default -> false; // not possible
-                            };
-                            if (branchMatched) {
-                                reader.insert(ifBlock.mainContent());
-                            } else {
-                                for (int i = 1; i < ifBlock.branches.size(); i++) {
-                                    final var branchCond = ifBlock.branchConditions.get(i - 1);
-                                    if ("else::[]".equals(branchCond)) {
-                                        reader.insert(ifBlock.branches.get(i));
-                                        break;
-                                    }
-                                    final var elsifLabel = branchCond.substring("elsif::".length(), branchCond.indexOf('['));
-                                    if (new ConditionalBlock.Ifdef(elsifLabel).test(ctx)) {
-                                        reader.insert(ifBlock.branches.get(i));
-                                        break;
-                                    }
-                                }
+                    // ifeval has no inline form so it is always a block, for ifdef/ifndef the brackets tell
+                    if (!enclosed.isBlank() && !"ifeval".equals(macro.name())) {
+                        if (branchMatched) { // give the line back to the loop, it is a header line as any other
+                            reader.insert(List.of(enclosed));
+                        }
+                        continue; // either way the header does not end here
+                    }
+
+                    final var ifBlock = readIfBlock(reader);
+                    if (branchMatched) {
+                        reader.insert(ifBlock.mainContent());
+                    } else {
+                        for (int i = 1; i < ifBlock.branches.size(); i++) {
+                            final var branchCond = ifBlock.branchConditions.get(i - 1);
+                            if ("else::[]".equals(branchCond)) {
+                                reader.insert(ifBlock.branches.get(i));
+                                break;
                             }
-                            continue;
-                        } else if ("include".equals(macro.name())) {
-                            doInclude(enclosingElement, macro, resolver, attributes, true);
-                            continue;
+                            final var elsifLabel = branchCond.substring("elsif::".length(), branchCond.indexOf('['));
+                            if (new ConditionalBlock.Ifdef(elsifLabel).test(ctx)) {
+                                reader.insert(ifBlock.branches.get(i));
+                                break;
+                            }
                         }
                     }
+                    continue;
+                } else if ("include".equals(macro.name()) && enclosed.isEmpty()) {
+                    doInclude(enclosingElement, macro, resolver, attributes, true);
+                    continue;
                 }
 
                 // not a preprocessor macro, as of asciidoctor it is a plain line of the header or of the body

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/parser/ParserTest.java
@@ -254,6 +254,83 @@ class ParserTest {
     }
 
     @Test
+    void parseHeaderWithInlineConditionals() { // ifdef::attr[content] has no endif, the content is a single line
+        {   // condition is false, the line is dropped but the header parsing goes on
+            final var header = new Parser().parseHeader(new Reader(List.of(
+                    "= Title",
+                    "ifdef::env-github[:imagesdir: ../assets/images/posts]",
+                    ":page-layout: post")));
+            assertEquals("Title", header.title());
+            assertEquals(Map.of("page-layout", "post", "authorcount", "0"), header.attributes());
+        }
+        {   // condition is true, the content is evaluated as a header line
+            final var header = new Parser(Map.of("env-github", "true")).parseHeader(new Reader(List.of(
+                    "= Title",
+                    "ifdef::env-github[:imagesdir: ../assets/images/posts]",
+                    ":page-layout: post")));
+            assertEquals("Title", header.title());
+            assertEquals(Map.of(
+                    "imagesdir", "../assets/images/posts",
+                    "page-layout", "post",
+                    "authorcount", "0"), header.attributes());
+        }
+        {   // the attribute the condition tests can be set by the header itself
+            final var header = new Parser().parseHeader(new Reader(List.of(
+                    "= Title",
+                    ":my-flag:",
+                    "ifdef::my-flag[:page-set-by-inline: yes]")));
+            assertEquals(Map.of(
+                    "my-flag", "",
+                    "page-set-by-inline", "yes",
+                    "authorcount", "0"), header.attributes());
+        }
+        {   // ifndef inline form
+            final var header = new Parser().parseHeader(new Reader(List.of(
+                    "= Title",
+                    "ifndef::env-github[:imagesdir: ./images]",
+                    ":page-layout: post")));
+            assertEquals(Map.of(
+                    "imagesdir", "./images",
+                    "page-layout", "post",
+                    "authorcount", "0"), header.attributes());
+        }
+    }
+
+    @Test
+    void parseHeaderWithMultipleAttributesConditionals() { // "," is an or, "+" is an and
+        final var orForm = List.of(
+                "= Title",
+                "ifdef::env-github,env-browser[:imagesdir: ../assets/images/posts]",
+                ":page-layout: post");
+        assertEquals(
+                Map.of("page-layout", "post", "authorcount", "0"),
+                new Parser().parseHeader(new Reader(orForm)).attributes());
+        assertEquals(
+                Map.of("imagesdir", "../assets/images/posts", "page-layout", "post", "authorcount", "0"),
+                new Parser(Map.of("env-browser", "true")).parseHeader(new Reader(orForm)).attributes());
+
+        final var andForm = List.of(
+                "= Title",
+                "ifdef::env-github+env-browser[:imagesdir: ../assets/images/posts]",
+                ":page-layout: post");
+        assertEquals(
+                Map.of("page-layout", "post", "authorcount", "0"),
+                new Parser(Map.of("env-github", "true")).parseHeader(new Reader(andForm)).attributes());
+        assertEquals(
+                Map.of("imagesdir", "../assets/images/posts", "page-layout", "post", "authorcount", "0"),
+                new Parser(Map.of("env-github", "true", "env-browser", "true")).parseHeader(new Reader(andForm)).attributes());
+
+        // as of asciidoctor an empty name is an undefined attribute so a trailing separator is never true
+        final var trailingSeparator = List.of(
+                "= Title",
+                "ifdef::env-github+[:imagesdir: ../assets/images/posts]",
+                ":page-layout: post");
+        assertEquals(
+                Map.of("page-layout", "post", "authorcount", "0"),
+                new Parser(Map.of("env-github", "true")).parseHeader(new Reader(trailingSeparator)).attributes());
+    }
+
+    @Test
     void parseHeaderAndContent() {
         final var doc = new Parser().parse(List.of("= Title", "", "++++", "pass", "++++"), new Parser.ParserContext(null));
         assertEquals("Title", doc.header().title());
@@ -2266,6 +2343,21 @@ class ParserTest {
                         new ConditionalBlock.Ifdef("foo"),
                         List.of(new Text(List.of(), "This is value.", Map.of())),
                         Map.of())),
+                body.children());
+    }
+
+    @Test
+    void inlineIfdef() { // ifdef::attr[content] has no endif::[], the lines after it are not part of the block
+        final var body = new Parser().parseBody(
+                new Reader(List.of("ifdef::foo[This is value.]", "After.")),
+                null);
+        assertEquals(
+                List.of(new Paragraph(List.of(
+                        new ConditionalBlock(
+                                new ConditionalBlock.Ifdef("foo"),
+                                List.of(new Text(List.of(), "This is value.", Map.of())),
+                                Map.of()),
+                        new Text(List.of(), "After.", Map.of())), Map.of())),
                 body.children());
     }
 

--- a/asciidoc-java/src/test/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRendererTest.java
+++ b/asciidoc-java/src/test/java/io/yupiik/asciidoc/renderer/html/AsciidoctorLikeHtmlRendererTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AsciidoctorLikeHtmlRendererTest {
@@ -615,6 +616,32 @@ class AsciidoctorLikeHtmlRendererTest {
                   </table>
                  </div>
                 """);
+    }
+
+    @Test
+    void inlineIfdef() { // ifdef::attr[content] renders its content when the attribute is set and never swallows what follows
+        final var doc = new Parser().parse(List.of("""
+                = Title
+
+                ifdef::foo[Only with foo.]
+                Always there.
+
+                Last paragraph.""".split("\n")), new Parser.ParserContext(null));
+        {
+            final var renderer = new AsciidoctorLikeHtmlRenderer(new AsciidoctorLikeHtmlRenderer.Configuration()
+                    .setAttributes(Map.of("noheader", "true")));
+            renderer.visit(doc);
+            final var html = renderer.result();
+            assertFalse(html.contains("Only with foo."), html);
+            assertTrue(html.contains("Always there.") && html.contains("Last paragraph."), html);
+        }
+        {
+            final var renderer = new AsciidoctorLikeHtmlRenderer(new AsciidoctorLikeHtmlRenderer.Configuration()
+                    .setAttributes(Map.of("noheader", "true", "foo", "")));
+            renderer.visit(doc);
+            final var html = renderer.result();
+            assertTrue(html.contains("Only with foo.") && html.contains("Always there.") && html.contains("Last paragraph."), html);
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #102

## What was broken

Only the block form of the conditional preprocessor macros, the one closed by a `endif::[]`, was known. The inline form `ifdef::attr[content]` carries its content in the brackets and has no `endif::[]`. It was mishandled in both places conditionals are read:

- In the header, `readAttributes()` tested `indexOf("[]")`, which is `-1` when the brackets hold anything, so the line fell through to the "plain line" case. The header ended there and every attribute below it was lost. This is the symptom reported in the issue.
- In the body, `readIfBlock()` looked for a `endif::[]` that never comes and swallowed the rest of the document into one conditional block, dropping the inline content itself. Same root cause, so it is fixed here too.

## What the fix does

- The brackets now tell the two forms apart: empty means a block, anything else means an inline whose content is the whole of the conditional.
- In the header the content is given back to the reader when the condition matches and dropped when it does not; either way header parsing goes on.
- In the body the content becomes the children of the `ConditionalBlock` and nothing more is read from the document.
- `ifeval` is excluded from the inline path since asciidoctor has no inline form for it.
- `ConditionalBlock.Ifdef` and `Ifndef` learned the multi-attribute conditions asciidoctor supports, `,` for an or and `+` for an and. The example in the issue (`ifdef::env-github,env-browser,env-vscode[...]`) relies on this; without it the header would parse but `imagesdir` would never be set.

## Verification

The three cases from the issue, from one reproducer against `master` and against this branch:

```
                                BEFORE (master)                AFTER
block form                      {page-layout=post}             {page-layout=post}
inline, condition false         {}                             {page-layout=post}
inline, env-github set          {}                             {imagesdir=../assets/images/posts, page-layout=post}
inline, condition true          {my-flag=}                     {page-set-by-inline=yes, my-flag=}
```

Checked against asciidoctor 2.0.26 rather than memory: for the header in the issue it renders `imagesdir` unset and `page-layout=post` with no attributes, and `imagesdir=../assets/images/posts` with `-a env-github`. The patched parser produces the same. The `,`/`+` truth table (including `ifndef` with both separators) matches asciidoctor for all four combinations of two attributes.

Tests: 314 pass in `asciidoc-java` (2 new tests: header cases and multi-attribute conditions in `ParserTest`, a body case in `ParserTest`, and an end-to-end `AsciidoctorLikeHtmlRendererTest` proving the inline content renders only when the attribute is set and never swallows what follows). 35 pass in `minisite-core`.

## Left out of scope, on purpose

Two adjacent issues surfaced while testing. Both predate this change and are shared with the block form, so they are filed separately.

- #127: `ifeval::[{version} > 1]` in a header is not recognized at all: `HEADER_MACRO` requires at least one character between `::` and `[`, and `ifeval` puts its whole condition inside the brackets, so the line is taken as the author line. Relaxing the regex also changes block-macro detection in the body parser.
- #128: a conditional block that directly adjoins paragraph text (block form or inline) renders without `<p>` and without a separator before the following line, because `visitParagraph`'s `addP` allowlist does not include `CONDITIONAL_BLOCK`. The block form `ifdef::foo[]` / `endif::[]` followed by a text line shows exactly the same output today.
